### PR TITLE
#9 Removed hard coded IP for Devtools, set to localhost.

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -63,7 +63,7 @@ void main() async {
     print(trace);
   }
 
-  final remoteDev = RemoteDevToolsMiddleware('192.168.1.207:8000');
+  final remoteDev = RemoteDevToolsMiddleware('localhost:8000');
 
   final store = Store<AppState>(
     appReducer,


### PR DESCRIPTION
I'm assuming at some point in the past, 'localhost:8000' would have pointed towards the device we're emulating on. (If it was,) That's not the case anymore, so the hard-coded IP address has been removed.

Closes #9 